### PR TITLE
Powershell statement requires quotes.

### DIFF
--- a/vision/README.md
+++ b/vision/README.md
@@ -52,7 +52,7 @@ export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service_account_key.json
    ```
    With PowerShell:
    ```sh
-   $env:GOOGLE_APPLICATION_CREDENTIALS= /path/to/service_account_key.json
+   $env:GOOGLE_APPLICATION_CREDENTIALS= '/path/to/service_account_key.json'
    ```
 ### Cloning the repository
 ```sh


### PR DESCRIPTION
Otherwise, powershell complains:
```ps1
/path/to/service_account_key.json : The term '/path/to/service_account_key.json' is not recognized as the name of a cmdlet, function, script file, or operable program.
Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
```