### PR TITLE
Update main class to correct class name

### DIFF
--- a/pubsub/build.gradle
+++ b/pubsub/build.gradle
@@ -33,7 +33,7 @@ apply plugin: 'kotlin'
 apply plugin: 'application'
 apply plugin: "org.jlleitschuh.gradle.ktlint"
 
-mainClassName = 'com.example.pubsub.PubSubExampleKt'
+mainClassName = 'com.example.pubsub.PubsubKt'
 
 defaultTasks 'run'
 
@@ -61,7 +61,7 @@ task wrapper(type: Wrapper) {
 
 jar {
     manifest {
-        attributes 'Main-Class': 'com.example.pubsub.PubSubExampleKt'
+        attributes 'Main-Class': 'com.example.pubsub.PubsubKt'
     }
 
     // This line of code recursively collects and copies all of a project's files


### PR DESCRIPTION
If you run anything from the jar currently, you'll get a `com.example.pubsub.PubSubExampleKt` class not found error. This updates the `mainClassName` to the correct main class of `PubsubKt`.

Clone of #54 but submitted from `origin` for tests