### PR TITLE
chore: skip tests from fork prs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,8 +25,9 @@ jobs:
     - run: echo ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_B64 }} | base64 --decode >> $GOOGLE_APPLICATION_CREDENTIALS
 
     - if: {{ env.GOOGLE_APPLICATION_CREDENTIALS = "" }}
-      run: echo "MAVEN_FLAGS=\"-Dmaven.test.skip=true\"" >> $GITHUB_ENV
-      run: echo "GRADLE_FLAGS=\"-x test\"" >> $GITHUB_ENV
+      run: |
+        echo "MAVEN_FLAGS=\"-Dmaven.test.skip=true\"" >> $GITHUB_ENV
+        echo "GRADLE_FLAGS=\"-x test\"" >> $GITHUB_ENV
 
     - name: App Engine (Ktor) - Gradle
       uses: eskatos/gradle-command-action@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,11 +30,9 @@ jobs:
         echo "GRADLE_FLAGS=\"-x test\"" >> $GITHUB_ENV
 
     - name: App Engine (Ktor) - Gradle
-      uses: eskatos/gradle-command-action@v1
-      with:
-        arguments: build $GRADLE_FLAGS
-        build-root-directory: appengine/ktor
-        wrapper-directory: appengine/ktor
+      run: |
+        cd ${GITHUB_WORKSPACE}/appengine/ktor
+        ./gradlew build $GRADLE_FLAGS
 
     - name: App Engine (Springboot) - Maven
       run: |
@@ -42,18 +40,14 @@ jobs:
         ./mvnw install -q $MAVEN_FLAGS
 
     - name: Firestore - Gradle
-      uses: eskatos/gradle-command-action@v1
-      with:
-        arguments: build $GRADLE_FLAGS
-        build-root-directory: firestore
-        wrapper-directory: firestore
+      run: |
+        cd ${GITHUB_WORKSPACE}/firestore
+        ./gradlew build $GRADLE_FLAGS
 
     - name: Functions - Gradle
-      uses: eskatos/gradle-command-action@v1
-      with:
-        arguments: build --console=plain --info $GRADLE_FLAGS
-        build-root-directory: functions
-        wrapper-directory: functions
+      run: |
+        cd ${GITHUB_WORKSPACE}/functions
+        ./gradlew build --console=plain --info $GRADLE_FLAGS
 
     - name: Getting Started Android (frontend) - Gradle
       run: |
@@ -68,18 +62,14 @@ jobs:
         ./mvnw install -q
 
     - name: Pubsub - Gradle
-      uses: eskatos/gradle-command-action@v1
-      with:
-        arguments: build --console=plain --info $GRADLE_FLAGS
-        build-root-directory: pubsub
-        wrapper-directory: pubsub
+      run: |
+        cd ${GITHUB_WORKSPACE}/pubsub
+        ./gradlew build --console=plain --info $GRADLE_FLAGS
 
     - name: Cloud Run (gRPC) - Gradle
-      uses: eskatos/gradle-command-action@v1
-      with:
-        arguments: build --console=plain --info $GRADLE_FLAGS
-        build-root-directory: run/grpc-hello-world-gradle
-        wrapper-directory: run/grpc-hello-world-gradle
+      run: |
+        cd ${GITHUB_WORKSPACE}/run/grpc-hello-world-gradle
+        ./gradlew build --console=plain --info $GRADLE_FLAGS
 
     - name: Cloud Run (gRPC) - Maven
       run: |
@@ -87,32 +77,24 @@ jobs:
         ./mvnw install -q $MAVEN_FLAGS
 
     - name: Cloud Run (gRPC streaming) - Gradle
-      uses: eskatos/gradle-command-action@v1
-      with:
-        arguments: build --console=plain --info $GRADLE_FLAGS
-        build-root-directory: run/grpc-hello-world-streaming
-        wrapper-directory: run/grpc-hello-world-streaming
+      run: |
+        cd ${GITHUB_WORKSPACE}/run/grpc-hello-world-streaming
+        ./gradlew build --console=plain --info $GRADLE_FLAGS
 
     - name: Cloud Run (gRPC bidi-streaming) - Gradle
-      uses: eskatos/gradle-command-action@v1
-      with:
-        arguments: build --console=plain --info $GRADLE_FLAGS
-        build-root-directory: run/grpc-hello-world-bidi-streaming
-        wrapper-directory: run/grpc-hello-world-bidi-streaming
+      run: |
+        cd ${GITHUB_WORKSPACE}/run/grpc-hello-world-bidi-streaming
+        ./gradlew build --console=plain --info $GRADLE_FLAGS
 
     - name: Cloud Run (Ktor) - Gradle
-      uses: eskatos/gradle-command-action@v1
-      with:
-        arguments: build --console=plain --info $GRADLE_FLAGS
-        build-root-directory: run/ktor-hello-world
-        wrapper-directory: run/ktor-hello-world
+      run: |
+        cd ${GITHUB_WORKSPACE}/run/ktor-hello-world
+        ./gradlew build --console=plain --info $GRADLE_FLAGS
 
     - name: Cloud Run (Micronaut) - Gradle
-      uses: eskatos/gradle-command-action@v1
-      with:
-        arguments: build --console=plain --info $GRADLE_FLAGS
-        build-root-directory: run/micronaut-hello-world
-        wrapper-directory: run/micronaut-hello-world
+      run: |
+        cd ${GITHUB_WORKSPACE}/run/micronaut-hello-world
+        ./gradlew build --console=plain --info $GRADLE_FLAGS
 
     - name: Cloud Run (Quarkus) - Maven
       run: |
@@ -120,18 +102,14 @@ jobs:
         ./mvnw install -q $MAVEN_FLAGS
 
     - name: Cloud Run (Spring Boot) - Gradle
-      uses: eskatos/gradle-command-action@v1
-      with:
-        arguments: build --console=plain --info $GRADLE_FLAGS
-        build-root-directory: run/springboot-hello-world
-        wrapper-directory: run/springboot-hello-world
+      run: |
+        cd ${GITHUB_WORKSPACE}/run/springboot-hello-world
+        ./gradlew build --console=plain --info $GRADLE_FLAGS
 
     - name: Cloud Run (Http4k) - Gradle
-      uses: eskatos/gradle-command-action@v1
-      with:
-        arguments: build --console=plain --info $GRADLE_FLAGS
-        build-root-directory: run/http4k-hello-world
-        wrapper-directory: run/http4k-hello-world
+      run: |
+        cd ${GITHUB_WORKSPACE}/run/http4k-hello-world
+        ./gradlew build --console=plain --info $GRADLE_FLAGS
 
     - name: Cloud Run (Plain) - Maven
       run: |
@@ -139,16 +117,12 @@ jobs:
         ./mvnw install -q $MAVEN_FLAGS
 
     - name: Storage - Gradle
-      uses: eskatos/gradle-command-action@v1
-      with:
-        arguments: build --console=plain --info $GRADLE_FLAGS
-        build-root-directory: storage
-        wrapper-directory: storage
+      run: |
+        cd ${GITHUB_WORKSPACE}/storage
+        ./gradlew build --console=plain --info $GRADLE_FLAGS
 
     - name: Vision - Gradle
-      uses: eskatos/gradle-command-action@v1
-      with:
-        arguments: build --console=plain --info $GRADLE_FLAGS
-        build-root-directory: vision
-        wrapper-directory: vision
+      run: |
+        cd ${GITHUB_WORKSPACE}/vision
+        ./gradlew build --console=plain --info $GRADLE_FLAGS
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
       run: echo "GOOGLE_APPLICATION_CREDENTIALS=${HOME}/credentials.json" >> $GITHUB_ENV
     - run: echo ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_B64 }} | base64 --decode >> $GOOGLE_APPLICATION_CREDENTIALS
 
-    - if: env.GOOGLE_APPLICATION_CREDENTIALS == ''
+    - if: secrets.GOOGLE_APPLICATION_CREDENTIALS_B64 == ''
       run: |
         echo "MAVEN_FLAGS=\"-Dmaven.test.skip=true\"" >> $GITHUB_ENV
         echo "GRADLE_FLAGS=\"-x test\"" >> $GITHUB_ENV

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
       run: echo "GOOGLE_APPLICATION_CREDENTIALS=${HOME}/credentials.json" >> $GITHUB_ENV
     - run: echo ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_B64 }} | base64 --decode >> $GOOGLE_APPLICATION_CREDENTIALS
 
-    - if: {{ env.GOOGLE_APPLICATION_CREDENTIALS = "" }}
+    - if: env.GOOGLE_APPLICATION_CREDENTIALS == ''
       run: |
         echo "MAVEN_FLAGS=\"-Dmaven.test.skip=true\"" >> $GITHUB_ENV
         echo "GRADLE_FLAGS=\"-x test\"" >> $GITHUB_ENV

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,7 @@ on:
 env:
   GOOGLE_CLOUD_PROJECT: ${{ secrets.GOOGLE_CLOUD_PROJECT }}
   GOOGLE_STORAGE_BUCKET: ${{ secrets.GOOGLE_CLOUD_PROJECT }}
+
 jobs:
   unit_tests:
     strategy:
@@ -23,29 +24,33 @@ jobs:
       run: echo "GOOGLE_APPLICATION_CREDENTIALS=${HOME}/credentials.json" >> $GITHUB_ENV
     - run: echo ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_B64 }} | base64 --decode >> $GOOGLE_APPLICATION_CREDENTIALS
 
+    - if: {{ env.GOOGLE_APPLICATION_CREDENTIALS = "" }}
+      run: echo "MAVEN_FLAGS=\"-Dmaven.test.skip=true\"" >> $GITHUB_ENV
+      run: echo "GRADLE_FLAGS=\"-x test\"" >> $GITHUB_ENV
+
     - name: App Engine (Ktor) - Gradle
       uses: eskatos/gradle-command-action@v1
       with:
-        arguments: build
+        arguments: build ${{env.GRADLE_FLAGS}}
         build-root-directory: appengine/ktor
         wrapper-directory: appengine/ktor
 
     - name: App Engine (Springboot) - Maven
       run: |
         cd ${GITHUB_WORKSPACE}/appengine/springboot
-        ./mvnw test -q
+        ./mvnw install -q ${{env.MAVEN_FLAGS}}
 
     - name: Firestore - Gradle
       uses: eskatos/gradle-command-action@v1
       with:
-        arguments: build
+        arguments: build ${{env.GRADLE_FLAGS}}
         build-root-directory: firestore
         wrapper-directory: firestore
 
     - name: Functions - Gradle
       uses: eskatos/gradle-command-action@v1
       with:
-        arguments: test --console=plain --info
+        arguments: build --console=plain --info ${{env.GRADLE_FLAGS}}
         build-root-directory: functions
         wrapper-directory: functions
 
@@ -53,96 +58,96 @@ jobs:
       run: |
         cd ${GITHUB_WORKSPACE}/getting-started/android-with-appengine/frontend
         echo ${{ secrets.GOOGLE_SERVICES_B64 }} | base64 --decode >> emojify/google-services.json
-        ./gradlew test --console=plain --info
+        ./gradlew build --console=plain --info ${{env.GRADLE_FLAGS}}
 
     - name: Getting Started Android (backend) - Maven
       run: |
         cd ${GITHUB_WORKSPACE}/getting-started/android-with-appengine/backend
         echo "storage.bucket.name = $GOOGLE_CLOUD_PROJECT.appspot.com" >> src/main/resources/application.properties
-        ./mvnw test -q
+        ./mvnw install -q
 
     - name: Pubsub - Gradle
       uses: eskatos/gradle-command-action@v1
       with:
-        arguments: test --console=plain --info
+        arguments: build --console=plain --info ${{env.GRADLE_FLAGS}}
         build-root-directory: pubsub
         wrapper-directory: pubsub
 
     - name: Cloud Run (gRPC) - Gradle
       uses: eskatos/gradle-command-action@v1
       with:
-        arguments: test --console=plain --info
+        arguments: build --console=plain --info ${{env.GRADLE_FLAGS}}
         build-root-directory: run/grpc-hello-world-gradle
         wrapper-directory: run/grpc-hello-world-gradle
 
     - name: Cloud Run (gRPC) - Maven
       run: |
         cd ${GITHUB_WORKSPACE}/run/grpc-hello-world-mvn
-        ./mvnw test -q
+        ./mvnw install -q ${{env.MAVEN_FLAGS}}
 
     - name: Cloud Run (gRPC streaming) - Gradle
       uses: eskatos/gradle-command-action@v1
       with:
-        arguments: test --console=plain --info
+        arguments: build --console=plain --info ${{env.GRADLE_FLAGS}}
         build-root-directory: run/grpc-hello-world-streaming
         wrapper-directory: run/grpc-hello-world-streaming
 
     - name: Cloud Run (gRPC bidi-streaming) - Gradle
       uses: eskatos/gradle-command-action@v1
       with:
-        arguments: test --console=plain --info
+        arguments: build --console=plain --info ${{env.GRADLE_FLAGS}}
         build-root-directory: run/grpc-hello-world-bidi-streaming
         wrapper-directory: run/grpc-hello-world-bidi-streaming
 
     - name: Cloud Run (Ktor) - Gradle
       uses: eskatos/gradle-command-action@v1
       with:
-        arguments: test --console=plain --info
+        arguments: build --console=plain --info ${{env.GRADLE_FLAGS}}
         build-root-directory: run/ktor-hello-world
         wrapper-directory: run/ktor-hello-world
 
     - name: Cloud Run (Micronaut) - Gradle
       uses: eskatos/gradle-command-action@v1
       with:
-        arguments: test --console=plain --info
+        arguments: build --console=plain --info ${{env.GRADLE_FLAGS}}
         build-root-directory: run/micronaut-hello-world
         wrapper-directory: run/micronaut-hello-world
 
     - name: Cloud Run (Quarkus) - Maven
       run: |
         cd ${GITHUB_WORKSPACE}/run/quarkus-hello-world
-        ./mvnw test -q
+        ./mvnw install -q ${{env.MAVEN_FLAGS}}
 
     - name: Cloud Run (Spring Boot) - Gradle
       uses: eskatos/gradle-command-action@v1
       with:
-        arguments: test --console=plain --info
+        arguments: build --console=plain --info ${{env.GRADLE_FLAGS}}
         build-root-directory: run/springboot-hello-world
         wrapper-directory: run/springboot-hello-world
 
     - name: Cloud Run (Http4k) - Gradle
       uses: eskatos/gradle-command-action@v1
       with:
-        arguments: test --console=plain --info
+        arguments: build --console=plain --info ${{env.GRADLE_FLAGS}}
         build-root-directory: run/http4k-hello-world
         wrapper-directory: run/http4k-hello-world
 
     - name: Cloud Run (Plain) - Maven
       run: |
         cd ${GITHUB_WORKSPACE}/run/plain-hello-world
-        ./mvnw test -q
+        ./mvnw install -q ${{env.MAVEN_FLAGS}}
 
     - name: Storage - Gradle
       uses: eskatos/gradle-command-action@v1
       with:
-        arguments: test --console=plain --info
+        arguments: build --console=plain --info ${{env.GRADLE_FLAGS}}
         build-root-directory: storage
         wrapper-directory: storage
 
     - name: Vision - Gradle
       uses: eskatos/gradle-command-action@v1
       with:
-        arguments: test --console=plain --info
+        arguments: build --console=plain --info ${{env.GRADLE_FLAGS}}
         build-root-directory: vision
         wrapper-directory: vision
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,8 +26,8 @@ jobs:
 
     - if:  github.event.pull_request.head.repo.full_name != github.repository
       run: |
-        echo "MAVEN_FLAGS=\"-Dmaven.test.skip=true\"" >> $GITHUB_ENV
-        echo "GRADLE_FLAGS=\"-x test\"" >> $GITHUB_ENV
+        echo "MAVEN_FLAGS='-Dmaven.test.skip=true'" >> $GITHUB_ENV
+        echo "GRADLE_FLAGS='-x test'" >> $GITHUB_ENV
 
     - name: App Engine (Ktor) - Gradle
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
       run: echo "GOOGLE_APPLICATION_CREDENTIALS=${HOME}/credentials.json" >> $GITHUB_ENV
     - run: echo ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_B64 }} | base64 --decode >> $GOOGLE_APPLICATION_CREDENTIALS
 
-    - if: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_B64 == '' }}
+    - if:  github.event.pull_request.head.repo.full_name != github.repository
       run: |
         echo "MAVEN_FLAGS=\"-Dmaven.test.skip=true\"" >> $GITHUB_ENV
         echo "GRADLE_FLAGS=\"-x test\"" >> $GITHUB_ENV

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
       run: echo "GOOGLE_APPLICATION_CREDENTIALS=${HOME}/credentials.json" >> $GITHUB_ENV
     - run: echo ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_B64 }} | base64 --decode >> $GOOGLE_APPLICATION_CREDENTIALS
 
-    - if: secrets.GOOGLE_APPLICATION_CREDENTIALS_B64 == ''
+    - if: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_B64 == '' }}
       run: |
         echo "MAVEN_FLAGS=\"-Dmaven.test.skip=true\"" >> $GITHUB_ENV
         echo "GRADLE_FLAGS=\"-x test\"" >> $GITHUB_ENV

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,26 +32,26 @@ jobs:
     - name: App Engine (Ktor) - Gradle
       uses: eskatos/gradle-command-action@v1
       with:
-        arguments: build ${{env.GRADLE_FLAGS}}
+        arguments: build $GRADLE_FLAGS
         build-root-directory: appengine/ktor
         wrapper-directory: appengine/ktor
 
     - name: App Engine (Springboot) - Maven
       run: |
         cd ${GITHUB_WORKSPACE}/appengine/springboot
-        ./mvnw install -q ${{env.MAVEN_FLAGS}}
+        ./mvnw install -q $MAVEN_FLAGS
 
     - name: Firestore - Gradle
       uses: eskatos/gradle-command-action@v1
       with:
-        arguments: build ${{env.GRADLE_FLAGS}}
+        arguments: build $GRADLE_FLAGS
         build-root-directory: firestore
         wrapper-directory: firestore
 
     - name: Functions - Gradle
       uses: eskatos/gradle-command-action@v1
       with:
-        arguments: build --console=plain --info ${{env.GRADLE_FLAGS}}
+        arguments: build --console=plain --info $GRADLE_FLAGS
         build-root-directory: functions
         wrapper-directory: functions
 
@@ -59,7 +59,7 @@ jobs:
       run: |
         cd ${GITHUB_WORKSPACE}/getting-started/android-with-appengine/frontend
         echo ${{ secrets.GOOGLE_SERVICES_B64 }} | base64 --decode >> emojify/google-services.json
-        ./gradlew build --console=plain --info ${{env.GRADLE_FLAGS}}
+        ./gradlew build --console=plain --info $GRADLE_FLAGS
 
     - name: Getting Started Android (backend) - Maven
       run: |
@@ -70,85 +70,85 @@ jobs:
     - name: Pubsub - Gradle
       uses: eskatos/gradle-command-action@v1
       with:
-        arguments: build --console=plain --info ${{env.GRADLE_FLAGS}}
+        arguments: build --console=plain --info $GRADLE_FLAGS
         build-root-directory: pubsub
         wrapper-directory: pubsub
 
     - name: Cloud Run (gRPC) - Gradle
       uses: eskatos/gradle-command-action@v1
       with:
-        arguments: build --console=plain --info ${{env.GRADLE_FLAGS}}
+        arguments: build --console=plain --info $GRADLE_FLAGS
         build-root-directory: run/grpc-hello-world-gradle
         wrapper-directory: run/grpc-hello-world-gradle
 
     - name: Cloud Run (gRPC) - Maven
       run: |
         cd ${GITHUB_WORKSPACE}/run/grpc-hello-world-mvn
-        ./mvnw install -q ${{env.MAVEN_FLAGS}}
+        ./mvnw install -q $MAVEN_FLAGS
 
     - name: Cloud Run (gRPC streaming) - Gradle
       uses: eskatos/gradle-command-action@v1
       with:
-        arguments: build --console=plain --info ${{env.GRADLE_FLAGS}}
+        arguments: build --console=plain --info $GRADLE_FLAGS
         build-root-directory: run/grpc-hello-world-streaming
         wrapper-directory: run/grpc-hello-world-streaming
 
     - name: Cloud Run (gRPC bidi-streaming) - Gradle
       uses: eskatos/gradle-command-action@v1
       with:
-        arguments: build --console=plain --info ${{env.GRADLE_FLAGS}}
+        arguments: build --console=plain --info $GRADLE_FLAGS
         build-root-directory: run/grpc-hello-world-bidi-streaming
         wrapper-directory: run/grpc-hello-world-bidi-streaming
 
     - name: Cloud Run (Ktor) - Gradle
       uses: eskatos/gradle-command-action@v1
       with:
-        arguments: build --console=plain --info ${{env.GRADLE_FLAGS}}
+        arguments: build --console=plain --info $GRADLE_FLAGS
         build-root-directory: run/ktor-hello-world
         wrapper-directory: run/ktor-hello-world
 
     - name: Cloud Run (Micronaut) - Gradle
       uses: eskatos/gradle-command-action@v1
       with:
-        arguments: build --console=plain --info ${{env.GRADLE_FLAGS}}
+        arguments: build --console=plain --info $GRADLE_FLAGS
         build-root-directory: run/micronaut-hello-world
         wrapper-directory: run/micronaut-hello-world
 
     - name: Cloud Run (Quarkus) - Maven
       run: |
         cd ${GITHUB_WORKSPACE}/run/quarkus-hello-world
-        ./mvnw install -q ${{env.MAVEN_FLAGS}}
+        ./mvnw install -q $MAVEN_FLAGS
 
     - name: Cloud Run (Spring Boot) - Gradle
       uses: eskatos/gradle-command-action@v1
       with:
-        arguments: build --console=plain --info ${{env.GRADLE_FLAGS}}
+        arguments: build --console=plain --info $GRADLE_FLAGS
         build-root-directory: run/springboot-hello-world
         wrapper-directory: run/springboot-hello-world
 
     - name: Cloud Run (Http4k) - Gradle
       uses: eskatos/gradle-command-action@v1
       with:
-        arguments: build --console=plain --info ${{env.GRADLE_FLAGS}}
+        arguments: build --console=plain --info $GRADLE_FLAGS
         build-root-directory: run/http4k-hello-world
         wrapper-directory: run/http4k-hello-world
 
     - name: Cloud Run (Plain) - Maven
       run: |
         cd ${GITHUB_WORKSPACE}/run/plain-hello-world
-        ./mvnw install -q ${{env.MAVEN_FLAGS}}
+        ./mvnw install -q $MAVEN_FLAGS
 
     - name: Storage - Gradle
       uses: eskatos/gradle-command-action@v1
       with:
-        arguments: build --console=plain --info ${{env.GRADLE_FLAGS}}
+        arguments: build --console=plain --info $GRADLE_FLAGS
         build-root-directory: storage
         wrapper-directory: storage
 
     - name: Vision - Gradle
       uses: eskatos/gradle-command-action@v1
       with:
-        arguments: build --console=plain --info ${{env.GRADLE_FLAGS}}
+        arguments: build --console=plain --info $GRADLE_FLAGS
         build-root-directory: vision
         wrapper-directory: vision
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,8 +26,8 @@ jobs:
 
     - if:  github.event.pull_request.head.repo.full_name != github.repository
       run: |
-        echo "MAVEN_FLAGS='-Dmaven.test.skip=true'" >> $GITHUB_ENV
-        echo "GRADLE_FLAGS='-x test'" >> $GITHUB_ENV
+        echo "MAVEN_FLAGS=-Dmaven.test.skip=true" >> $GITHUB_ENV
+        echo "GRADLE_FLAGS=-x test" >> $GITHUB_ENV
 
     - name: App Engine (Ktor) - Gradle
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,13 +49,15 @@ jobs:
         cd ${GITHUB_WORKSPACE}/functions
         ./gradlew build --console=plain --info $GRADLE_FLAGS
 
-    - name: Getting Started Android (frontend) - Gradle
+    - if:  github.event.pull_request.head.repo.full_name == github.repository
+      name: Getting Started Android (frontend) - Gradle
       run: |
         cd ${GITHUB_WORKSPACE}/getting-started/android-with-appengine/frontend
         echo ${{ secrets.GOOGLE_SERVICES_B64 }} | base64 --decode >> emojify/google-services.json
         ./gradlew build --console=plain --info $GRADLE_FLAGS
 
-    - name: Getting Started Android (backend) - Maven
+    - if:  github.event.pull_request.head.repo.full_name == github.repository
+      name: Getting Started Android (backend) - Maven
       run: |
         cd ${GITHUB_WORKSPACE}/getting-started/android-with-appengine/backend
         echo "storage.bucket.name = $GOOGLE_CLOUD_PROJECT.appspot.com" >> src/main/resources/application.properties


### PR DESCRIPTION
See #141 for this same PR submitted from a fork 

When a PR is submitted from a fork, run `gradle build` or `mvn install` but skip the tests. This is because many of the tests rely on `GOOGLE_APPLICATION_CREDENTIALS`, which are not available from forks.