### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
     - id: set-testdirs
-      run: echo "::set-output name=testdirs::[$(for i in $(ls -d */); do echo -n \"${i%%/}\",; done | sed 's/.$//')]"
+      run: echo "testdirs=[$(for i in $(ls -d */); do echo -n \"${i%%/}\",; done | sed 's/.$//')]" >> "$GITHUB_OUTPUT"
     outputs:
       testdirs: ${{ steps.set-testdirs.outputs.testdirs }}
   unit_tests:


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter